### PR TITLE
[Vessel] - Autofix finished with jarvis@main

### DIFF
--- a/bad_case.c
+++ b/bad_case.c
@@ -10,15 +10,18 @@ int test1603(int x)
 		break;
 	case 3:	
 		x--;
+		// Intentional fall-through is not recommended, so break is added:
+		break;
 	default:
-	    ;
+		// No operations are done here, but break is still required:
+		break;
 	}
 
 	return x;
 }
 
 short test0902(int x, int y, short e){
-   short buf[ 3 ][ 2 ] = { 1, 2, 0, 0, 5, 6 }; // MISRA_C_2012_09_02
+    short buf[3][2] = { { 1, 2 }, { 0, 0 }, { 5, 6 } }; // Fixed to comply with MISRA_C_2012_09_02
    buf[x][y] = e;
    return buf[x][y];
 }


### PR DESCRIPTION
# Vessel have completed autofix session. Requesting merge

## Violation diagnose results before jarvis patch
| Severity | Count |
|----------|-------|
|**Major** | 5 |
| Minor | 1 |
| Trivial | 0 |
| Weak | 0 |
|**Total**| 6 |



<details><summary>Click here to extend violation info</summary>

 Major - 함수 main의 파라미터가 없지만 명시적인 void 타입 파라미터를 선언하지 않았음

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/test.c#L4

 Major - 함수 main의 파라미터가 없지만 명시적인 void 타입 파라미터를 선언하지 않았음

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/test.c#L4

 Minor - case문에서 Break문을 생략하면 안됨

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/bad_case.c#L5

 Major - 문장이 있는 switch절이 throw나 break문으로 끝나지 않음 

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/bad_case.c#L13

 Major - 문장이 있는 switch절이 throw나 break문으로 끝나지 않음 

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/bad_case.c#L11

 Major - 객체 buf[0]의 초기화가 큰 괄호('{ }')로 둘러싸여있지 않음

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/bad_case.c#L21

</details>

## Violation diagnose results after jarvis patch
| Severity | Count |
|----------|-------|
|**Major** | 2 |
| Minor | 0 |
| Trivial | 0 |
| Weak | 0 |
|**Total**| 2 |



<details><summary>Click here to extend violation info</summary>

 Major - 함수 main의 파라미터가 없지만 명시적인 void 타입 파라미터를 선언하지 않았음

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/test.c#L4

 Major - 함수 main의 파라미터가 없지만 명시적인 void 타입 파라미터를 선언하지 않았음

https://github.com/minhyuk/jarvis-demo/blob/8f11a5ef24ad2e6d43e23a77a404bd1909afe8e8/test.c#L4

</details>

## Violation Change
| Severity | Count Before | Count After | Change |
|----------|--------------|-------------|--------|
|**Major** | 5 | 2 | 3 |
| Minor | 1 | 0 | 1 |
| Trivial | 0 | 0 | 0 |
| Weak | 0 | 0 | 0 |
|**Total**| 6 | 2 | 4 |

